### PR TITLE
Add Custom rules to define rules directly against model

### DIFF
--- a/src/Rules/ValueInList.php
+++ b/src/Rules/ValueInList.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace atk4\validate\Rules;
+
+use atk4\data\Model;
+
+/**
+ * Class ValueInList
+ *
+ * Validate : if value is present against a Model Field
+ *
+ * Rule code : atk4_value_in_list
+ *
+ * @example ['atk4_value_in_list',$model,'field_to_check']
+ * @example ['atk4_value_in_list',$model->ref('model_to_check'),'field_to_check']
+ *
+ * @package atk4\validate\Rules
+ */
+class ValueInList extends aRule implements iRule
+{
+    
+    public static function getCallback($field, $value, array $params, array $fields): bool
+    {
+        $errors = [];
+        
+        if (count($params) != 2) {
+            $errors[] = 'need 2 params';
+        }
+        
+        if (isset($params[0]) && !($params[0] instanceof Model)) {
+            $errors[] = 'first param must be \atk4\data\Model';
+        }
+        
+        if (isset($params[1]) && !is_string($params[1])) {
+            $errors[] = 'second param must be string';
+        }
+        
+        if (count($errors) > 0) {
+            throw new \Exception(static::getName() . ' ' . implode(', ', $errors) . ' (Model $model,string $field)');
+        }
+        
+        $model = $params[0]; // Model used for check
+        
+        $fieldCheck = $params[1]; // Field name used for check
+        
+        $model = $model->newInstance();
+        $model->addCondition($fieldCheck, '=', $value);
+        
+        $action = $model->action('count');
+        $count  = (int)$action->getOne();
+        
+        return ($count > 0) ? true : false;
+    }
+    
+    public static function getMessages(): array
+    {
+        return [
+            'en' => '{field} is not in list',
+            'it' => '{field} già nella lista',
+            'ro' => '{field} deja în listă',
+        ];
+    }
+}

--- a/src/Rules/ValueNotInList.php
+++ b/src/Rules/ValueNotInList.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Copyright (c) 2019.
+ *
+ * Francesco "Abbadon1334" Danti <fdanti@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace atk4\validate\Rules;
+
+use atk4\data\Model;
+
+/**
+ * Class ValueNotInList
+ *
+ * Validate : if value is NOT present against a Model Field
+ *
+ * Rule code : atk4_value_not_in_list
+ *
+ * @example ['atk4_value_not_in_list',$model,'field_to_check']
+ * @example ['atk4_value_not_in_list',$model->ref('model_to_check'),'field_to_check']
+ *
+ * @package atk4\validate\Rules
+ */
+class ValueNotInList extends aRule implements iRule
+{
+    
+    public static function getCallback($field, $value, array $params, array $fields): bool
+    {
+        $errors = [];
+        
+        if (count($params) != 2) {
+            $errors[] = 'need 2 params';
+        }
+        
+        if (isset($params[0]) && !($params[0] instanceof Model)) {
+            $errors[] = 'first param must be \atk4\data\Model';
+        }
+        
+        if (isset($params[1]) && !is_string($params[1])) {
+            $errors[] = 'second param must be string';
+        }
+        
+        if (count($errors) > 0) {
+            throw new \Exception(static::getName() . ' ' . implode(', ', $errors) . ' (Model $model,string $field)');
+        }
+        
+        $model = $params[0]; // Model used for check
+        
+        $fieldCheck = $params[1]; // Field name used for check
+        
+        $model = $model->newInstance();
+        $model->addCondition($fieldCheck, '=', $value);
+        
+        $action = $model->action('count');
+        $count  = (int)$action->getOne();
+        
+        return ($count > 0) ? false : true;
+    }
+    
+    public static function getMessages(): array
+    {
+        return [
+            'en' => '{field} is in list',
+            'it' => '{field} non nella lista',
+            'ro' => '{field} nu este în listă',
+        ];
+    }
+}

--- a/src/Rules/ValueUnique.php
+++ b/src/Rules/ValueUnique.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace atk4\validate\Rules;
+
+use atk4\data\Model;
+
+/**
+ * Class ValueUnique
+ *
+ * Validate : if value is unique in Model in his field
+ *
+ * Rule code : atk4_value_unique
+ *
+ * @example ['atk4_value_unique',$model]
+ *
+ * @package atk4\validate\Rules
+ */
+
+class ValueUnique extends aRule implements iRule
+{
+    
+    public static function getCallback($field, $value, array $params, array $fields): bool
+    {
+        $errors = [];
+    
+        if (count($params) != 1) {
+            $errors[] = 'need 1 param';
+        }
+    
+        if (isset($params[0]) && !($params[0] instanceof Model)) {
+            $errors[] = 'first param must be \atk4\data\Model';
+        }
+    
+        if (count($errors) > 0) {
+            throw new \Exception(static::getName() . ' ' . implode(', ', $errors) . ' (Model $model,string $field)');
+        }
+    
+        $model = $params[0]; // Model used for check
+    
+        $isLoaded = $model->loaded(); // if loaded ? INSERT : UPDATE
+        
+        $model = $model->newInstance();
+        $model->addCondition($field, '=', $value);
+        
+        $action = $model->action('count');
+        $count  = (int)$action->getOne();
+        
+        // if more than 1 is always false;
+        if ($count > 1) {
+            /**
+             * @TODO throw exception this must not happen?
+             */
+            return false;
+        }
+        
+        // if is loaded must be 1;
+        if ($isLoaded && $count == 1) {
+            return true;
+        }
+        
+        // if is not loaded must be 0;
+        if (!$isLoaded && $count == 0) {
+            return true;
+        }
+        
+        return false;
+    }
+    
+    public static function getMessages(): array
+    {
+        return [
+            'en' => '{field} must be unique',
+            'it' => '{field} non è unico',
+            'ro' => '{field} nu este unic',
+        ];
+    }
+}

--- a/src/Rules/ValueUniqueOther.php
+++ b/src/Rules/ValueUniqueOther.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace atk4\validate\Rules;
+
+use atk4\data\Model;
+
+/**
+ * Class ValueUniqueOther
+ *
+ * Validate : if value is unique in Model in another field
+ *
+ * Rule code : atk4_value_unique_other
+ *
+ * @example ['atk4_value_unique_other',$model,'field_name_to_check']
+ *
+ * @package atk4\validate\Rules
+ */
+
+class ValueUniqueOther extends aRule implements iRule
+{
+    
+    public static function getCallback($field, $value, array $params, array $fields): bool
+    {
+        $errors = [];
+    
+        if (count($params) != 2) {
+            $errors[] = 'need 2 params';
+        }
+    
+        if (isset($params[0]) && !($params[0] instanceof Model)) {
+            $errors[] = 'first param must be \atk4\data\Model';
+        }
+    
+        if (isset($params[1]) && !is_string($params[1])) {
+            $errors[] = 'second param must be string';
+        }
+    
+        if (count($errors) > 0) {
+            throw new \Exception(static::getName() . ' ' . implode(', ', $errors) . ' (Model $model,string $field)');
+        }
+    
+        $model = $params[0]; // Model used for check
+    
+        $fieldCheck = $params[1]; // Field name used for check
+        
+        $isLoaded = $model->loaded(); // if loaded ? INSERT : UPDATE
+        
+        $model = $model->newInstance();
+        $model->addCondition($fieldCheck, '=', $value);
+        
+        $action = $model->action('count');
+        $count  = (int)$action->getOne();
+        
+        // if more than 1 is always false;
+        if ($count > 1)
+        {
+            /**
+             * @TODO throw exception this must not happen?
+             */
+            return false;
+        }
+        
+        // if is loaded must be 1;
+        if ($isLoaded && $count == 1) {
+            return true;
+        }
+    
+        // if is not loaded must be 0;
+        if (!$isLoaded && $count == 0) {
+            return true;
+        }
+        
+        return false;
+    }
+    
+    public static function getMessages(): array
+    {
+        return [
+            'en' => '{field} must be unique',
+            'it' => '{field} non è unico',
+            'ro' => '{field} nu este unic',
+        ];
+    }
+}

--- a/src/Rules/aRule.php
+++ b/src/Rules/aRule.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace atk4\validate\Rules;
+
+use Valitron\Validator;
+
+/**
+ * Class aRule
+ * has an abstract must be left alone to his destiny :)
+ *
+ * and extend it like this :
+ *
+ * class RuleName extends aRule implements iRule {
+ *
+ *      public static function getCallback($field, $value, array $params, array $fields): bool
+ *      {
+ *
+ *      }
+ *
+ *      public static function getMessages(): array;
+ *      {
+ *
+ *      }
+ * }
+ *
+ * @package atk4\validate\Rules
+ */
+abstract class aRule
+{
+    /**
+     * Entry point for adding rule
+     * you don't have to call this, it will be called one time :
+     *  - in method atk4/validate->validate()
+     *
+     * it will be called another time :
+     *  - if you have reset the language of \Valitron\Validate
+     *
+     * @throws \Exception
+     */
+    public static function setup()
+    {
+        Validator::addRule(
+            static::getName(), [
+                static::class,
+                "getCallback",
+            ],
+            static::getMessage()
+        );
+    }
+    
+    /**
+     * return the name of the rule, using classname of the rule decamelized
+     *
+     * atk4ValueInList => atk4_value_in_list
+     *
+     * @return string
+     */
+    protected static function getName()
+    {
+        $path      = explode('\\', static::class);
+        $ClassName = array_pop($path);
+        
+        return 'atk4_' . static::decamelize($ClassName);
+    }
+    
+    /**
+     * decamelize class name
+     *
+     * @return string
+     */
+    private static function decamelize($string)
+    {
+        return strtolower(preg_replace([
+                                           '/([a-z\d])([A-Z])/',
+                                           '/([^_])([A-Z][a-z])/',
+                                       ], '$1_$2', $string));
+    }
+    
+    /**
+     * get localized validation error message from extended Custom rule
+     *
+     * @return string
+     * @throws \Exception
+     */
+    public static function getMessage(): string
+    {
+        $validatorLanguage = Validator::lang();
+        $messages          = static::getMessages();
+        
+        if (isset($messages[$validatorLanguage])) {
+            return $messages[$validatorLanguage];
+        }
+        
+        
+        if (!isset($messages['en'])) {
+            throw new \Exception('Rule must have at least english translation');
+        }
+        
+        return $messages['en'];
+    }
+    
+    /**
+     * add here only to not have error in QC
+     *
+     * if rule is extended correctly this will not be called
+     * if called throw exception
+     *
+     * @param       $field
+     * @param       $value
+     * @param array $params
+     * @param array $fields
+     *
+     * @return bool
+     * @throws \Exception
+     */
+    public static function getCallback($field, $value, array $params, array $fields): bool
+    {
+        throw new \Exception('getCallback must be implemented in extended aRule class');
+    }
+}

--- a/src/Rules/iRule.php
+++ b/src/Rules/iRule.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace atk4\validate\Rules;
+
+interface iRule
+{
+    public static function getCallback($field, $value, array $params, array $fields): bool;
+    
+    public static function getMessages(): array;
+}

--- a/tests/CustomRulesTest.php
+++ b/tests/CustomRulesTest.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace atk4\validate\tests;
+
+use atk4\data\Model;
+use atk4\validate\Validator;
+
+class CustomRulesTest extends \atk4\schema\PHPUnit_SchemaTestCase
+{
+    
+    public $m;
+    
+    public $c;
+    
+    public function setUp()
+    {
+        parent::setUp();
+        
+        $this->m   = new TestModel($this->db);
+    
+        $migration = $this->getMigration($this->m);
+        $migration->create();
+        
+        for ($a = 0; $a < 10; $a++) {
+            
+            $data = [
+                'v_value' => 'v_' . $a,
+                'o_value' => 'o_' . $a,
+            ];
+            
+            $this->m->unload()->set($data)->save();
+        }
+        
+        $this->m->unload();
+    }
+    
+    // test ValueUnique
+    
+    public function testUnique()
+    {
+    
+        $this->c = new TestableValidatorCalls($this->m);
+        
+        $this->c->rule('v_value', [
+            ['atk4_value_unique', $this->m]
+        ]);
+        
+        $data = [
+            'v_value' => 'v_10',
+            'o_value' => 'o_10',
+        ];
+        
+        $err = $this->m->unload()->set($data)->validate();
+        
+        $this->assertEquals([], array_keys($err));
+    }
+    
+    public function testUniqueError()
+    {
+        $this->c = new TestableValidatorCalls($this->m);
+    
+        $this->c->rule('v_value', [
+            ['atk4_value_unique', $this->m]
+        ]);
+        
+        $data = [
+            'v_value' => 'v_1',
+            'o_value' => 'o_1',
+        ];
+        
+        $err = $this->m->unload()->set($data)->validate();
+        
+        $this->assertEquals(['v_value'], array_keys($err));
+    }
+    
+    // test ValueUniqueOther
+    public function testUniqueOther()
+    {
+        $this->c = new TestableValidatorCalls($this->m);
+    
+        $this->c->rule('v_value', [
+            ['atk4_value_unique_other', $this->m, 'o_value']
+        ]);
+        
+        $data = [
+            'v_value' => 'o_10',
+        ];
+        
+        $err = $this->m->unload()->set($data)->validate();
+        
+        $this->assertEquals([], array_keys($err));
+    }
+    
+    public function testUniqueOtherError()
+    {
+        $this->c = new TestableValidatorCalls($this->m);
+    
+        $this->c->rule('v_value', [
+            ['atk4_value_unique_other', $this->m, 'o_value']
+        ]);
+        
+        $data = [
+            'v_value' => 'o_1',
+        ];
+        
+        $err = $this->m->unload()->set($data)->validate();
+        
+        $this->assertEquals(['v_value'], array_keys($err));
+    }
+    
+    // test ValueInList
+    public function testValueInList()
+    {
+        $this->c = new TestableValidatorCalls($this->m);
+    
+        $this->c->rule('v_value', [
+            ['atk4_value_in_list', $this->m, 'o_value']
+        ]);
+        
+        $data = [
+            'v_value' => 'o_1',
+        ];
+        
+        $err = $this->m->unload()->set($data)->validate();
+        
+        $this->assertEquals([], array_keys($err));
+    }
+    
+    public function testValueInListError()
+    {
+        $this->c = new TestableValidatorCalls($this->m);
+    
+        $this->c->rule('v_value', [
+            ['atk4_value_in_list', $this->m, 'o_value']
+        ]);
+        
+        $data = [
+            'v_value' => 'o_10',
+        ];
+        
+        $err = $this->m->unload()->set($data)->validate();
+        
+        $this->assertEquals(['v_value'], array_keys($err));
+    }
+    
+    // test ValueNotInList
+    public function testValueNotInList()
+    {
+        $this->c = new TestableValidatorCalls($this->m);
+    
+        $this->c->rule('v_value', [
+            ['atk4_value_not_in_list', $this->m, 'o_value']
+        ]);
+        
+        $data = [
+            'v_value' => 'o_10',
+        ];
+        
+        $err = $this->m->unload()->set($data)->validate();
+        
+        $this->assertEquals([], array_keys($err));
+    }
+    
+    public function testValueNotInListError()
+    {
+        $this->c = new TestableValidatorCalls($this->m);
+    
+        $this->c->rule('v_value', [
+            ['atk4_value_not_in_list', $this->m, 'o_value']
+        ]);
+        
+        $data = [
+            'v_value' => 'o_1',
+        ];
+        
+        $err = $this->m->unload()->set($data)->validate();
+        
+        $this->assertEquals(['v_value'], array_keys($err));
+    }
+    
+    public function testValueChangedLanguage()
+    {
+        $this->c = new TestableValidatorCalls($this->m);
+        
+        $this->c->rule('v_value', [
+            ['atk4_value_not_in_list', $this->m, 'o_value']
+        ]);
+        
+        $data = [
+            'v_value' => 'o_1',
+        ];
+    
+        \Valitron\Validator::lang('it');
+    
+        $saved_err = $this->m->unload()->set($data)->validate(); // load 1
+    
+        \Valitron\Validator::lang('en');
+    
+        $saved_err = $this->m->unload()->set($data)->validate(); // load 2
+    
+        \Valitron\Validator::lang('it');
+    
+        $saved_err = $this->m->unload()->set($data)->validate(); // load 3
+    
+        \Valitron\Validator::lang('en');
+    
+        $err = $this->m->unload()->set($data)->validate(); // load 4
+        $err = $this->m->unload()->set($data)->validate(); // load 4
+        $err = $this->m->unload()->set($data)->validate(); // load 4
+        $err = $this->m->unload()->set($data)->validate(); // load 4
+        $err = $this->m->unload()->set($data)->validate(); // load 4
+        
+        $this->assertNotEquals($saved_err['v_value'], $err['v_value']);
+    
+        $this->assertEquals(4,$this->c->getCalledLoad());
+    }
+    
+    protected function tearDown()
+    {
+        $m = new TestModel($this->db);
+        $this->dropTable($m->table);
+    }
+}
+
+
+class TestModel extends Model
+{
+    public $table = 'model_table';
+    
+    public function init()
+    {
+        parent::init();
+        
+        $this->addField('v_value');
+        $this->addField('o_value');
+    }
+}
+
+class TestableValidatorCalls extends Validator {
+    
+    public static $calledLoad    = 0;
+    
+    public function getCalledLoad()
+    {
+        return static::$calledLoad;
+    }
+    
+    protected static function _addCustomRuleDefinition()
+    {
+        $tryLoad = parent::_addCustomRuleDefinition();
+        
+        if($tryLoad)
+        {
+            static::$calledLoad++;
+        }
+        
+        return $tryLoad;
+    }
+}


### PR DESCRIPTION
creare a simple way and strict ( interface + abstract ) to add custom rules that validate not only over data in model, but directly to model

in place of write : 
``` php
        $model = $model->newInstance();
        $model->addCondition($field, '=', $value);
        
        $action = $model->action('count');
        $count  = (int)$action->getOne();
                
        // if is loaded must be 1;
        if ($isLoaded && $count == 1) {
            return true;
        }
        
        // if is not loaded must be 0;
        if (!$isLoaded && $count == 0) {
            return true;
        }
```
can be used in validation definition like this :

``` php
$validator->rule('email', [ ['atk4_value_unique', $userModel] ]);
```

what do you think?

